### PR TITLE
feat: Replaced generic error toast with custom error stages

### DIFF
--- a/idkit/src/components/IDKitWidget/States/ErrorState.tsx
+++ b/idkit/src/components/IDKitWidget/States/ErrorState.tsx
@@ -5,9 +5,10 @@ import { XMarkIcon } from '@heroicons/react/20/solid'
 
 const getParams = ({ retryFlow, errorState }: IDKitStore) => ({ retryFlow, errorState })
 
-const ERROR_TITLES: Record<ErrorCodes, string> = {
+export const ERROR_TITLES: Record<ErrorCodes, string> = {
 	[ErrorCodes.GENERIC_ERROR]: 'Something went wrong',
 	[ErrorCodes.INVALID_CODE]: 'Invalid code',
+	[ErrorCodes.PHONE_OTP_REQUEST_ERROR]: 'We could not send you a code',
 	[ErrorCodes.REJECTED_BY_HOST_APP]: 'Verification declined by app',
 }
 
@@ -29,7 +30,7 @@ const ErrorState = () => {
 				</p>
 				<p className="mt-2 text-center text-lg text-gray-400">
 					{/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-					{errorState?.message || 'Please try to verify again in a moment'}
+					{errorState?.message || 'Please try again in a moment.'}
 				</p>
 			</div>
 			<div className="flex justify-center">
@@ -40,6 +41,11 @@ const ErrorState = () => {
 				>
 					Try Again
 				</button>
+			</div>
+			<div>
+				<p className="mt-4 text-xs text-gray-400">
+					If you are the app owner, check the console for further details.
+				</p>
 			</div>
 		</div>
 	)

--- a/idkit/src/components/PhoneInput.tsx
+++ b/idkit/src/components/PhoneInput.tsx
@@ -42,7 +42,7 @@ const PhoneInput = ({ disabled, onSubmit }: { disabled?: boolean; onSubmit?: () 
 					onChange={e => setPhoneNumber(e.target.value)}
 					className="block w-full rounded-md border-transparent bg-transparent pl-6 focus:border-transparent focus:ring-transparent dark:text-white sm:text-sm"
 					disabled={disabled}
-					onKeyDown={e => e.key === 'Enter' && onSubmit?.()}
+					onKeyDown={e => e.key === 'Enter' && void onSubmit?.()}
 				/>
 			</div>
 		</Fragment>

--- a/idkit/src/services/phone.ts
+++ b/idkit/src/services/phone.ts
@@ -1,4 +1,4 @@
-import type { PhoneSignalProof, PhoneVerificationChannel } from '@/types'
+import type { PhoneRequestErrorCodes, PhoneSignalProof, PhoneVerificationChannel } from '@/types'
 
 const API_BASE_URL = 'https://developer.worldcoin.org/api/v1'
 
@@ -41,7 +41,7 @@ export async function verifyCode(
 }
 
 interface RequestCodeError {
-	code: 'max_attempts' | 'server_error' | 'timeout'
+	code: PhoneRequestErrorCodes
 	detail: string
 }
 

--- a/idkit/src/store/idkit.ts
+++ b/idkit/src/store/idkit.ts
@@ -52,11 +52,9 @@ const useIDKitStore = create<IDKitStore>()((set, get) => ({
 	setCode: code => set({ code }),
 	setStage: stage => set({ stage }),
 	setErrorState: errorState => set({ errorState }),
-	setErrorTitle: errorTitle => set({ errorTitle }),
-	setErrorDetail: errorDetail => set({ errorDetail }),
 	setPhoneNumber: phoneNumber => set({ phoneNumber }),
 	setProcessing: (processing: boolean) => set({ processing }),
-	retryFlow: () => set({ stage: IDKITStage.ENTER_PHONE, phoneNumber: '', errorTitle: '', errorDetail: '' }),
+	retryFlow: () => set({ stage: IDKITStage.ENTER_PHONE, phoneNumber: '', errorState: null }),
 	addSuccessCallback: (cb: CallbackFn, source: ConfigSource) => {
 		set(state => {
 			state.successCallbacks[source] = cb

--- a/idkit/src/types/index.ts
+++ b/idkit/src/types/index.ts
@@ -39,7 +39,7 @@ export interface IErrorState {
 
 export enum ErrorCodes {
 	GENERIC_ERROR = 'GENERIC_ERROR',
-	PHONE_ERROR = 'PHONE_ERROR', // Phone number is rejected
+	PHONE_OTP_REQUEST_ERROR = 'PHONE_OTP_REQUEST_ERROR',
 	INVALID_CODE = 'INVALID_CODE', // OTP code is invalid
 	REJECTED_BY_HOST_APP = 'REJECTED_BY_HOST_APP', // Host app rejected the verification request
 }
@@ -53,4 +53,11 @@ export interface ExpectedErrorResponse {
 export enum PhoneVerificationChannel {
 	SMS = 'sms',
 	Call = 'call',
+}
+
+export enum PhoneRequestErrorCodes {
+	MAX_ATTEMPTS = 'max_attempts',
+	TIMEOUT = 'timeout',
+	UNSUPPORTED_COUNTRY = 'unsupported_country',
+	SERVER_ERROR = 'server_error',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,28 +3466,6 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@worldcoin/idkit@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@worldcoin/idkit/-/idkit-0.0.1.tgz#21e10428ceb61c2e53ead436657ac9896b844fb2"
-  integrity sha512-DWu0VBigIsWjNKnD9HS2JOTZlEhswqKfiuUwGbW7GymyM77e0eJ1Gy+WFMJR7xmpPuuwaD9NuN5v/mn9cZtopw==
-  dependencies:
-    "@fontsource/rubik" "^4.5.11"
-    "@headlessui/react" "^1.7.4"
-    "@heroicons/react" "^2.0.13"
-    "@radix-ui/react-dialog" "^1.0.2"
-    "@radix-ui/react-scroll-area" "^1.0.2"
-    "@radix-ui/react-select" "^1.1.2"
-    "@radix-ui/react-toast" "^1.1.2"
-    "@tailwindcss/forms" "^0.5.3"
-    country-telephone-data "^0.6.3"
-    framer-motion "^7.6.7"
-    phone "^3.1.30"
-    react-countdown "^2.3.4"
-    react-country-flag "^3.0.2"
-    react-frame-component "^5.2.3"
-    react-shadow "^19.0.3"
-    zustand "^4.1.4"
-
 "@xobotyi/scrollbar-width@1.9.5":
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"


### PR DESCRIPTION
[Issue #30](https://github.com/worldcoin/idkit-js/issues/30)

Replaces the generic error toast on phone request errors with a customized error stage.  Details from the dev-portal error response.

Examples: Generic & Timeout
![CleanShot 2023-01-04 at 13 06 41@2x](https://user-images.githubusercontent.com/19291506/210624978-9a4c7c6b-3d09-4b38-8bae-95d198dda941.png)
