### PR TITLE
fix: qr logo positioning

### DIFF
--- a/idkit/src/components/QRCode.tsx
+++ b/idkit/src/components/QRCode.tsx
@@ -82,8 +82,8 @@ const Qrcode = ({ data, logoSize = 72, size = 300 }: Props) => {
 	const logoPosition = size / 2 - logoSize / 2
 
 	return (
-		<div className="dark:bg-0d151d w-max rounded-lg bg-white" style={{ height: size, width: size }}>
-			<div className="relative flex h-0 w-full justify-center" style={{ top: logoPosition }}>
+		<div className="dark:bg-0d151d relative w-max rounded-lg bg-white" style={{ height: size, width: size }}>
+			<div className="absolute flex h-0 w-full justify-center" style={{ top: logoPosition }}>
 				<WorldcoinLogomark height={logoSize} width={logoSize} />
 			</div>
 			<svg height={size} width={size}>


### PR DESCRIPTION

Minor fix: 
QR code logo has a position relative and it moves down as planned, but it still takes some space in its initial position. 
- Set `position: relative` to container
- Set `position: absolute` to the logo

---
https://user-images.githubusercontent.com/89008845/221614437-3f0a5e85-28fb-46c2-a648-abbe61c5c01c.mp4