### PR TITLE
Enable to select response_type on sign in

### DIFF
--- a/idkit/src/components/SignInWithWorldID.tsx
+++ b/idkit/src/components/SignInWithWorldID.tsx
@@ -9,12 +9,13 @@ import type { IDKitConfig, WidgetConfig } from '@/types/config'
 
 type Props = Omit<WidgetConfig, 'autoClose'> &
 	Pick<IDKitConfig, 'app_id' | 'walletConnectProjectId'> & {
+		response_type: 'code' | 'id_token' | 'token'
 		nonce?: string
 		onSuccess: (jwt: string) => void
 		children?: ({ open }: { open: () => void }) => JSX.Element
 	}
 
-const SignInWithWorldID: FC<Props> = ({ onSuccess, app_id, nonce, theme, children, ...props }) => {
+const SignInWithWorldID: FC<Props> = ({ onSuccess, app_id, nonce, theme, response_type, children, ...props }) => {
 	const [token, setToken] = useState<string>('')
 	const signal = useMemo<string>(() => {
 		if (nonce) return nonce
@@ -28,7 +29,7 @@ const SignInWithWorldID: FC<Props> = ({ onSuccess, app_id, nonce, theme, childre
 				headers: {
 					'Content-Type': 'application/json',
 				},
-				body: JSON.stringify({ ...proof, app_id, nonce: signal, response_type: 'id_token' }),
+				body: JSON.stringify({ ...proof, app_id, nonce: signal, response_type: response_type }),
 			})
 
 			if (!response.ok) {
@@ -43,7 +44,7 @@ const SignInWithWorldID: FC<Props> = ({ onSuccess, app_id, nonce, theme, childre
 			const { jwt } = (await response.json()) as { jwt: string }
 			setToken(jwt)
 		},
-		[app_id, signal]
+		[app_id, signal, response_type]
 	)
 
 	const onIDKitSuccess = useCallback(() => void onSuccess(token), [onSuccess, token])


### PR DESCRIPTION
Fixed #109 
I enabled to select response_type.

Sample code.
```
				<SignInWithWorldID
					nonce="z-dkEmoy_ujfk7B8uTiQpp"
					app_id="app_staging_bdde51f6c88010a57aec659b733f18b4"
					response_type="token" 
				>
					{({ open }) => <button onClick={open}>Click me</button>}
				</SignInWithWorldID>
```

payload

![スクリーンショット 2023-04-15 14 49 48](https://user-images.githubusercontent.com/6723743/232187104-fccaeee2-b136-476c-8abf-35bc21e28898.png)
