### PR TITLE
fix: qr code copied animation

### DIFF
--- a/idkit/src/components/IDKitWidget/States/WorldID/QRState.tsx
+++ b/idkit/src/components/IDKitWidget/States/WorldID/QRState.tsx
@@ -40,13 +40,33 @@ const QRState: FC<Props> = ({ qrData, showQR, setShowQR }) => {
 								key="copied"
 								initial="hidden"
 								animate="visible"
-								exit="hidden"
+								exit="exit"
 								variants={{
-									visible: { y: 0, opacity: 1 },
-									hidden: { y: '100%', opacity: 0 },
-									exit: { y: '100%', opacity: 0, transition: { duration: 0.5 } },
+									hidden: { opacity: 0, height: 0, marginTop: 0, y: 0 },
+									visible: {
+										opacity: 1,
+										height: 'auto',
+										marginTop: 8,
+										y: 6,
+										transition: {
+											duration: 0.25,
+											opacity: { delay: 0.05, duration: 0.2 },
+											ease: 'easeInOut',
+										},
+									},
+									exit: {
+										opacity: 0,
+										height: 0,
+										marginTop: 0,
+										y: 0,
+										transition: {
+											duration: 0.4,
+											delay: 0.1,
+											opacity: { duration: 0.25, delay: 0 },
+											ease: 'easeInOut',
+										},
+									},
 								}}
-								transition={{ duration: 0.5, ease: 'easeInOut' }}
 							>
 								<span className="border-f1f5f8 rounded-lg border py-1 px-2 text-sm">
 									{__('QR Code copied')}


### PR DESCRIPTION
reuses code from https://github.com/worldcoin/world-id-sign-in/pull/45 to improve animation when clicking QR code to copy the link

old jarring animation:
https://github.com/worldcoin/idkit-js/assets/29718876/25871f88-c0eb-431a-a69b-ed7a82b3dd6f

new smooth animation:
https://github.com/worldcoin/idkit-js/assets/29718876/5ca98839-9ac4-4282-8828-21baf4583226