### PR TITLE
feat: set package privacy & send `credential_types` by default

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0-alpha.0",
 	"homepage": "https://docs.worldcoin.org/id/idkit",
 	"license": "MIT",
+	"private": false,
 	"description": "The identity SDK. Privacy-preserving identity and proof of personhood with World ID.",
 	"repository": {
 		"type": "git",

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand'
 import { buffer_decode } from './lib/utils'
-import type { IDKitConfig } from '@/types/config'
 import { VerificationState } from '@/types/bridge'
 import type { AppErrorCodes } from '@/types/bridge'
 import type { ISuccessResult } from '@/types/result'
 import { encodeAction, generateSignal } from '@/lib/hashing'
+import { CredentialType, type IDKitConfig } from '@/types/config'
 import { decryptResponse, encryptRequest, exportKey, generateKey } from '@/lib/crypto'
 
 const DEFAULT_BRIDGE_URL = 'https://bridge.worldcoin.org'
@@ -78,7 +78,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 					iv,
 					JSON.stringify({
 						app_id,
-						credential_types,
+						credential_types: credential_types ?? [CredentialType.Orb],
 						action_description,
 						action: encodeAction(action),
 						signal: generateSignal(signal).digest,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0-alpha.0",
 	"homepage": "https://docs.worldcoin.org/id/idkit",
 	"license": "MIT",
+	"private": false,
 	"description": "The identity SDK. Privacy-preserving identity and proof of personhood with World ID.",
 	"repository": {
 		"type": "git",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0-alpha.0",
 	"homepage": "https://docs.worldcoin.org/id/idkit",
 	"license": "MIT",
+	"private": false,
 	"description": "The identity SDK. Privacy-preserving identity and proof of personhood with World ID.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- If not provided, `credential_types` defaults to `[CredentialType.Orb]`
- Sets explicit privacy of packages as public.