### PR TITLE
feat: idkit state and error handling improvements

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -141,6 +141,8 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 		set({
 			iv: null,
 			key: null,
+			result: null,
+			errorCode: null,
 			requestId: null,
 			connectorURI: null,
 			verificationState: VerificationState.PreparingClient,

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { buffer_decode } from './lib/utils'
+import { AppErrorCodes } from '@/types/bridge'
 import { VerificationState } from '@/types/bridge'
-import type { AppErrorCodes } from '@/types/bridge'
 import type { ISuccessResult } from '@/types/result'
 import { encodeAction, generateSignal } from '@/lib/hashing'
 import { CredentialType, type IDKitConfig } from '@/types/config'
@@ -111,6 +111,13 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 		if (!key) throw new Error('No keypair found. Please call `createClient` first.')
 
 		const res = await fetch(`${get().bridge_url}/response/${get().requestId}`)
+
+		if (!res.ok) {
+			return set({
+				errorCode: AppErrorCodes.ConnectionFailed,
+				verificationState: VerificationState.Failed,
+			})
+		}
 
 		const { response, status } = (await res.json()) as BridgeResponse
 

--- a/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
@@ -57,9 +57,14 @@ const WorldIDState = () => {
 		}
 
 		if (result) {
+			if (!credential_types?.includes(result.credential_type)) {
+				setStage(IDKITStage.ERROR)
+				setErrorState({ code: AppErrorCodes.CredentialUnavailable })
+				return
+			}
 			return handleVerify(result)
 		}
-	}, [result, handleVerify, verificationState, setStage, errorCode, setErrorState])
+	}, [result, handleVerify, verificationState, setStage, errorCode, setErrorState, credential_types])
 
 	return (
 		<div className="-mt-6 space-y-6">

--- a/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
@@ -59,7 +59,7 @@ const WorldIDState = () => {
 		if (result) {
 			return handleVerify(result)
 		}
-	}, [result, reset, handleVerify, verificationState, setStage, errorCode, setErrorState])
+	}, [result, handleVerify, verificationState, setStage, errorCode, setErrorState])
 
 	return (
 		<div className="-mt-6 space-y-6">

--- a/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
@@ -58,6 +58,9 @@ const WorldIDState = () => {
 
 		if (result) {
 			if (!credential_types?.includes(result.credential_type)) {
+				console.error(
+					'Credential type returned does not match configured credential_types. This should only happen when manually selecting disallowed credentials in the Worldcoin Simulator.'
+				)
 				setStage(IDKITStage.ERROR)
 				setErrorState({ code: AppErrorCodes.CredentialUnavailable })
 				return

--- a/packages/react/src/store/idkit.ts
+++ b/packages/react/src/store/idkit.ts
@@ -140,6 +140,9 @@ const useIDKitStore = createWithEqualityFn<IDKitStore>()(
 		handleVerify: (result: ISuccessResult) => {
 			set({ stage: IDKITStage.HOST_APP_VERIFICATION, processing: false })
 
+			// the `async` added below ensures that we properly handle errors thrown by the callbacks if they are defined as synchronous functions
+			// without it, if `handleVerify` was a synchronous function and it threw an error, the error would not be caught by the promise chain to be properly displayed in IDKit
+			// this has no effect on the callbacks if they are defined as asynchronous functions
 			Promise.all(Object.values(get().verifyCallbacks).map(async cb => cb?.(result))).then(
 				() => {
 					set({ stage: IDKITStage.SUCCESS, result })

--- a/packages/react/src/store/idkit.ts
+++ b/packages/react/src/store/idkit.ts
@@ -140,7 +140,7 @@ const useIDKitStore = createWithEqualityFn<IDKitStore>()(
 		handleVerify: (result: ISuccessResult) => {
 			set({ stage: IDKITStage.HOST_APP_VERIFICATION, processing: false })
 
-			Promise.all(Object.values(get().verifyCallbacks).map(cb => cb?.(result))).then(
+			Promise.all(Object.values(get().verifyCallbacks).map(async cb => cb?.(result))).then(
 				() => {
 					set({ stage: IDKITStage.SUCCESS, result })
 


### PR DESCRIPTION
Resolves an issue I demo'd to @m1guelpf where IDKit would resubmit a proof to callback functions when it was reopened. The bridge store in `idkit-core` wasn't clearing the `result` and `errorCode` on reset, so these values were getting picked up again when entering `WorldIDState`.

Also adds proper error when a proof request times out (such as when a user never scans the QR code or never clicks "Verify with World ID" in the app). This is a distinct error from a user rejecting a proof request.

Also fixes an issue where if an error was thrown synchronously in `handleVerify`, the error would not be properly displayed by IDKit. Resolved by always calling `handleVerify` callbacks as async so the thrown error is handled as promise rejection.

Also ensures that the `credential_type` returned in the proof matches the configured accepted `credential_types`. This should only happen when manually selecting the wrong credential in the Simulator (as World App should prevent the proof from being generated at all if the requested credential is not available), but it's a good check to have.