### PR TITLE
fix!: handle credential_types check when using default

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -1,19 +1,13 @@
 import { create } from 'zustand'
-import { buffer_decode } from './lib/utils'
-import { AppErrorCodes } from '@/types/bridge'
+import { type IDKitConfig } from '@/types/config'
 import { VerificationState } from '@/types/bridge'
 import type { ISuccessResult } from '@/types/result'
 import { encodeAction, generateSignal } from '@/lib/hashing'
-import { CredentialType, type IDKitConfig } from '@/types/config'
+import { AppErrorCodes, ResponseStatus } from '@/types/bridge'
+import { buffer_decode, credential_types_or_default } from './lib/utils'
 import { decryptResponse, encryptRequest, exportKey, generateKey } from '@/lib/crypto'
 
 const DEFAULT_BRIDGE_URL = 'https://bridge.worldcoin.org'
-
-export enum ResponseStatus {
-	Retrieved = 'retrieved',
-	Completed = 'completed',
-	Initialized = 'initialized',
-}
 
 type BridgeResponse =
 	| {
@@ -35,17 +29,8 @@ export type WorldBridgeStore = {
 	errorCode: AppErrorCodes | null
 	verificationState: VerificationState
 
-	createClient: (
-		app_id: IDKitConfig['app_id'],
-		action: IDKitConfig['action'],
-		signal?: IDKitConfig['signal'],
-		bridge_url?: IDKitConfig['bridge_url'],
-		credential_types?: IDKitConfig['credential_types'],
-		action_description?: IDKitConfig['action_description']
-	) => Promise<void>
-
+	createClient: (config: IDKitConfig) => Promise<void>
 	pollForUpdates: () => Promise<void>
-
 	reset: () => void
 }
 
@@ -59,14 +44,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 	bridge_url: DEFAULT_BRIDGE_URL,
 	verificationState: VerificationState.PreparingClient,
 
-	createClient: async (
-		app_id: IDKitConfig['app_id'],
-		action: IDKitConfig['action'],
-		signal?: IDKitConfig['signal'],
-		bridge_url?: IDKitConfig['bridge_url'],
-		credential_types?: IDKitConfig['credential_types'],
-		action_description?: IDKitConfig['action_description']
-	) => {
+	createClient: async ({ bridge_url, app_id, credential_types, action_description, action, signal }) => {
 		const { key, iv } = await generateKey()
 
 		const res = await fetch(`${bridge_url ?? DEFAULT_BRIDGE_URL}/request`, {
@@ -78,7 +56,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 					iv,
 					JSON.stringify({
 						app_id,
-						credential_types: credential_types ?? [CredentialType.Orb],
+						credential_types: credential_types_or_default(credential_types),
 						action_description,
 						action: encodeAction(action),
 						signal: generateSignal(signal).digest,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,5 @@ export {
 } from '@/types'
 
 export { useWorldBridgeStore, WorldBridgeStore } from '@/bridge'
+
+export { DEFAULT_CREDENTIAL_TYPES } from '@/lib/utils'

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -1,4 +1,8 @@
+import { CredentialType } from '..'
+import type { IDKitConfig } from '..'
 import { Buffer } from 'buffer/index.js'
+
+export const DEFAULT_CREDENTIAL_TYPES = [CredentialType.Orb]
 
 export const buffer_encode = (buffer: ArrayBuffer): string => {
 	return Buffer.from(buffer).toString('base64')
@@ -6,4 +10,8 @@ export const buffer_encode = (buffer: ArrayBuffer): string => {
 
 export const buffer_decode = (encoded: string): ArrayBuffer => {
 	return Buffer.from(encoded, 'base64')
+}
+
+export const credential_types_or_default = (credential_types: IDKitConfig['credential_types']): CredentialType[] => {
+	return credential_types?.length ? credential_types : DEFAULT_CREDENTIAL_TYPES
 }

--- a/packages/core/src/types/bridge.ts
+++ b/packages/core/src/types/bridge.ts
@@ -19,3 +19,9 @@ export enum VerificationState {
 	Confirmed = 'confirmed',
 	Failed = 'failed',
 }
+
+export enum ResponseStatus {
+	Retrieved = 'retrieved',
+	Completed = 'completed',
+	Initialized = 'initialized',
+}

--- a/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
@@ -57,9 +57,9 @@ const WorldIDState = () => {
 		}
 
 		if (result) {
-			if (!(credential_types ?? ['orb']).includes(result.credential_type)) {
+			if (!credential_types.includes(result.credential_type)) {
 				console.error(
-					'Credential type returned does not match configured credential_types. This should only happen when manually selecting disallowed credentials in the Worldcoin Simulator.'
+					'Credential type received from wallet does not match configured credential_types. This should only happen when manually selecting disallowed credentials in the Worldcoin Simulator.'
 				)
 				setStage(IDKITStage.ERROR)
 				setErrorState({ code: AppErrorCodes.CredentialUnavailable })

--- a/packages/react/src/services/wld-bridge.ts
+++ b/packages/react/src/services/wld-bridge.ts
@@ -24,7 +24,14 @@ export const useWorldBridge = (
 
 	useEffect(() => {
 		if (!connectorURI) {
-			void createClient(app_id, action, signal, bridge_url, ref_credential_types.current, action_description)
+			void createClient({
+				app_id,
+				action,
+				signal,
+				bridge_url,
+				credential_types: ref_credential_types.current,
+				action_description,
+			})
 		}
 	}, [app_id, action, signal, action_description, createClient, ref_credential_types, bridge_url, connectorURI])
 

--- a/packages/react/src/store/idkit.ts
+++ b/packages/react/src/store/idkit.ts
@@ -7,6 +7,7 @@ import { createWithEqualityFn } from 'zustand/traditional'
 import {
 	AppErrorCodes,
 	CredentialType,
+	DEFAULT_CREDENTIAL_TYPES,
 	type IErrorState,
 	type IDKitConfig,
 	type ISuccessResult,
@@ -18,7 +19,7 @@ export type IDKitStore = {
 	signal: IDKitConfig['signal']
 	bridge_url?: IDKitConfig['bridge_url']
 	action_description?: IDKitConfig['action_description']
-	credential_types?: IDKitConfig['credential_types']
+	credential_types: NonNullable<IDKitConfig['credential_types']>
 
 	open: boolean
 	stage: IDKITStage
@@ -54,7 +55,7 @@ const useIDKitStore = createWithEqualityFn<IDKitStore>()(
 		action: '',
 		action_description: '',
 		bridge_url: '',
-		credential_types: [],
+		credential_types: DEFAULT_CREDENTIAL_TYPES,
 
 		open: false,
 		result: null,
@@ -118,9 +119,8 @@ const useIDKitStore = createWithEqualityFn<IDKitStore>()(
 			}: Config,
 			source: ConfigSource
 		) => {
-			const sanitized_credential_types = credential_types?.filter(type =>
-				Object.values(CredentialType).includes(type)
-			)
+			const sanitizedCredentialTypes =
+				credential_types?.filter(type => Object.values(CredentialType).includes(type)) ?? []
 
 			set({
 				theme,
@@ -129,7 +129,7 @@ const useIDKitStore = createWithEqualityFn<IDKitStore>()(
 				app_id,
 				autoClose,
 				bridge_url,
-				credential_types: sanitized_credential_types,
+				credential_types: sanitizedCredentialTypes.length ? sanitizedCredentialTypes : DEFAULT_CREDENTIAL_TYPES,
 				action_description,
 			})
 


### PR DESCRIPTION
- **breaking change** refactors `createClient` in `idkit-core` to receive input parameters in an object instead of positional arguments.
- fixes an issue introduced by #194 where if `credential_types` was unset in IDKit parameters, an error would always be thrown upon proof response from bridge
- makes it explicit how we handle credential_types by default