### PR TITLE
feat: return verification_level instead of credential_type

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -1,11 +1,17 @@
 import { create } from 'zustand'
-import { DEFAULT_VERIFICATION_LEVEL, buffer_decode, verification_level_to_credential_types } from './lib/utils'
-import { type IDKitConfig } from '@/types/config'
 import { VerificationState } from '@/types/bridge'
 import type { ISuccessResult } from '@/types/result'
+import type { CredentialType } from '@/types/config'
 import { encodeAction, generateSignal } from '@/lib/hashing'
 import { AppErrorCodes, ResponseStatus } from '@/types/bridge'
+import { VerificationLevel, type IDKitConfig } from '@/types/config'
 import { decryptResponse, encryptRequest, exportKey, generateKey } from '@/lib/crypto'
+import {
+	DEFAULT_VERIFICATION_LEVEL,
+	buffer_decode,
+	credential_type_to_verification_level,
+	verification_level_to_credential_types,
+} from './lib/utils'
 
 const DEFAULT_BRIDGE_URL = 'https://bridge.worldcoin.org'
 
@@ -18,6 +24,11 @@ type BridgeResponse =
 			status: ResponseStatus.Completed
 			response: { iv: string; payload: string }
 	  }
+
+type BridgeResult =
+	| ISuccessResult
+	| (Omit<ISuccessResult, 'verification_level'> & { credential_type: CredentialType })
+	| { error_code: AppErrorCodes }
 
 export type WorldBridgeStore = {
 	bridge_url: string
@@ -59,7 +70,10 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 						action_description,
 						action: encodeAction(action),
 						signal: generateSignal(signal).digest,
-						credential_types: verification_level_to_credential_types(verification_level ?? DEFAULT_VERIFICATION_LEVEL),
+						credential_types: verification_level_to_credential_types(
+							verification_level ?? DEFAULT_VERIFICATION_LEVEL
+						),
+						verification_level,
 					})
 				)
 			),
@@ -108,18 +122,36 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 			})
 		}
 
-		const result = JSON.parse(await decryptResponse(key, buffer_decode(response.iv), response.payload)) as
-			| ISuccessResult
-			| { error_code: AppErrorCodes }
+		const result = JSON.parse(
+			await decryptResponse(key, buffer_decode(response.iv), response.payload)
+		) as BridgeResult
 
 		if ('error_code' in result) {
 			return set({
 				errorCode: result.error_code,
 				verificationState: VerificationState.Failed,
 			})
+		} else if ('credential_type' in result) {
+			const processedResult = {
+				verification_level: credential_type_to_verification_level(result.credential_type),
+				...result,
+			} satisfies ISuccessResult
+			set({
+				result: processedResult,
+				verificationState: VerificationState.Confirmed,
+				key: null,
+				connectorURI: null,
+				requestId: null,
+			})
+		} else {
+			set({
+				result,
+				verificationState: VerificationState.Confirmed,
+				key: null,
+				connectorURI: null,
+				requestId: null,
+			})
 		}
-
-		set({ result, verificationState: VerificationState.Confirmed, key: null, connectorURI: null, requestId: null })
 	},
 
 	reset: () => {

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -73,7 +73,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 						credential_types: verification_level_to_credential_types(
 							verification_level ?? DEFAULT_VERIFICATION_LEVEL
 						),
-						verification_level,
+						verification_level: verification_level ?? DEFAULT_VERIFICATION_LEVEL,
 					})
 				)
 			),

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -122,7 +122,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 			})
 		}
 
-		const result = JSON.parse(
+		let result = JSON.parse(
 			await decryptResponse(key, buffer_decode(response.iv), response.payload)
 		) as BridgeResult
 
@@ -131,27 +131,22 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 				errorCode: result.error_code,
 				verificationState: VerificationState.Failed,
 			})
-		} else if ('credential_type' in result) {
-			const processedResult = {
+		}
+
+        if ('credential_type' in result) {
+			result = {
 				verification_level: credential_type_to_verification_level(result.credential_type),
 				...result,
 			} satisfies ISuccessResult
-			set({
-				result: processedResult,
-				verificationState: VerificationState.Confirmed,
-				key: null,
-				connectorURI: null,
-				requestId: null,
-			})
-		} else {
-			set({
-				result,
-				verificationState: VerificationState.Confirmed,
-				key: null,
-				connectorURI: null,
-				requestId: null,
-			})
 		}
+
+        set({
+            result,
+            key: null,
+            requestId: null,
+            connectorURI: null,
+            verificationState: VerificationState.Confirmed,
+        })
 	},
 
 	reset: () => {

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -124,7 +124,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 
 		let result = JSON.parse(
 			await decryptResponse(key, buffer_decode(response.iv), response.payload)
-		) satisfies BridgeResult
+		) as BridgeResult
 
 		if ('error_code' in result) {
 			return set({
@@ -133,20 +133,20 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 			})
 		}
 
-        if ('credential_type' in result) {
+		if ('credential_type' in result) {
 			result = {
 				verification_level: credential_type_to_verification_level(result.credential_type),
 				...result,
 			} satisfies ISuccessResult
 		}
 
-        set({
-            result,
-            key: null,
-            requestId: null,
-            connectorURI: null,
-            verificationState: VerificationState.Confirmed,
-        })
+		set({
+			result,
+			key: null,
+			requestId: null,
+			connectorURI: null,
+			verificationState: VerificationState.Confirmed,
+		})
 	},
 
 	reset: () => {

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -124,7 +124,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 
 		let result = JSON.parse(
 			await decryptResponse(key, buffer_decode(response.iv), response.payload)
-		) as BridgeResult
+		) satisfies BridgeResult
 
 		if ('error_code' in result) {
 			return set({

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -12,7 +12,7 @@ export const buffer_decode = (encoded: string): ArrayBuffer => {
 }
 
 /**
- * @deprecated use to transition to verification levels from credential types
+ * @dev use to convert verification level to accepted credential types for proof request
  * @param verification_level
  * @returns
  */
@@ -24,5 +24,21 @@ export const verification_level_to_credential_types = (verification_level: Verif
 			return [CredentialType.Orb]
 		default:
 			throw new Error(`Unknown verification level: ${verification_level}`)
+	}
+}
+
+/**
+ * @dev use to convert credential type to verification level upon proof response
+ * @param verification_level
+ * @returns
+ */
+export const credential_type_to_verification_level = (credential_type: CredentialType): VerificationLevel => {
+	switch (credential_type) {
+		case CredentialType.Orb:
+			return VerificationLevel.Orb
+		case CredentialType.Device:
+			return VerificationLevel.Lite
+		default:
+			throw new Error(`Unknown credential_type: ${credential_type}`)
 	}
 }

--- a/packages/core/src/types/result.ts
+++ b/packages/core/src/types/result.ts
@@ -1,11 +1,11 @@
 import type { AppErrorCodes } from './bridge'
-import type { CredentialType } from './config'
+import type { VerificationLevel } from './config'
 
 export interface ISuccessResult {
 	proof: string
 	merkle_root: string
 	nullifier_hash: string
-	credential_type: CredentialType
+	verification_level: VerificationLevel
 }
 
 export interface IErrorState {

--- a/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldIDState.tsx
@@ -10,7 +10,7 @@ import AboutWorldID from '@/components/AboutWorldID'
 import { useWorldBridge } from '@/services/wld-bridge'
 import LoadingIcon from '@/components/Icons/LoadingIcon'
 import WorldcoinIcon from '@/components/Icons/WorldcoinIcon'
-import { AppErrorCodes, VerificationState, verification_level_to_credential_types } from '@worldcoin/idkit-core'
+import { AppErrorCodes, VerificationState, VerificationLevel } from '@worldcoin/idkit-core'
 
 const getOptions = (store: IDKitStore) => ({
 	signal: store.signal,
@@ -57,8 +57,7 @@ const WorldIDState = () => {
 		}
 
 		if (result) {
-			const credential_types = verification_level_to_credential_types(verification_level)
-			if (!credential_types.includes(result.credential_type)) {
+			if (verification_level == VerificationLevel.Orb && result.verification_level == VerificationLevel.Lite) {
 				console.error(
 					'Credential type received from wallet does not match configured credential_types. This should only happen when manually selecting disallowed credentials in the Worldcoin Simulator.'
 				)


### PR DESCRIPTION
ISuccessResult now uses verification_level instead of credential_type. this handles conversion of returned credential_type from identity wallet to verification_level