### PR TITLE
fix: width and centering text on success state

### DIFF
--- a/packages/react/src/components/IDKitWidget/States/SuccessState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/SuccessState.tsx
@@ -11,7 +11,7 @@ const SuccessState = () => {
 				<p className="text-center text-2xl font-semibold text-gray-900 dark:text-white">
 					{__('Successfully verified')}
 				</p>
-				<p className="text-657080 mt-2 max-w-[14rem] text-center text-lg">
+				<p className="mx-auto mt-2 max-w-[224px] text-center text-lg text-657080">
 					{__('Your World ID verification was successful')}
 				</p>
 			</div>


### PR DESCRIPTION
<img width="473" alt="Screenshot 2023-12-12 at 11 47 24 PM" src="https://github.com/worldcoin/idkit-js/assets/29718876/9566c6f8-04e7-40e6-bf0d-2083ec91609e">

fixes the issue pictured above (only impacts shopify)