### PR TITLE
fix: Redirect Links from App after Verification

### DIFF
--- a/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
@@ -30,7 +30,11 @@ const QRState: FC<Props> = ({ qrData, showQR, setShowQR }) => {
 		<>
 			<div className="mb-10 space-y-4 md:hidden">
 				<motion.a
-					href={qrData ? qrData + `&return_to=${encodeURIComponent(window.location.href + '#anchor')}` : ''}
+					href={
+						qrData
+							? qrData + `&return_to=${encodeURIComponent(window.location.href + '#prevent_reload')}`
+							: ''
+					}
 					whileTap={{ scale: 0.95 }}
 					whileHover={{ scale: 1.05 }}
 					transition={{ layout: { duration: 0.15 } }}

--- a/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
@@ -30,7 +30,7 @@ const QRState: FC<Props> = ({ qrData, showQR, setShowQR }) => {
 		<>
 			<div className="mb-10 space-y-4 md:hidden">
 				<motion.a
-					href={qrData ? qrData + `&return_to=${encodeURIComponent(window.location.href)}` : ''}
+					href={qrData ? qrData + `&return_to=${encodeURIComponent(window.location.href + '#anchor')}` : ''}
 					whileTap={{ scale: 0.95 }}
 					whileHover={{ scale: 1.05 }}
 					transition={{ layout: { duration: 0.15 } }}

--- a/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
@@ -32,6 +32,7 @@ const QRState: FC<Props> = ({ qrData, showQR, setShowQR }) => {
 				<motion.a
 					href={
 						qrData
+							// added a dummy anchor to prevent reload (and loss of state) when returning to website on mobile device
 							? qrData + `&return_to=${encodeURIComponent(window.location.href + '#prevent_reload')}`
 							: ''
 					}


### PR DESCRIPTION
Adding an anchor will prevent the page from refreshing once you've confirmed with Idkit. Should also be fine for when you re use the same verification since it'll just add another anchor. See video below


https://github.com/worldcoin/idkit-js/assets/41224501/a14db6c5-b99d-4ae4-87b9-f14f39e8965e

