### PR TITLE
fix: remove return_to

### DIFF
--- a/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
@@ -30,12 +30,7 @@ const QRState: FC<Props> = ({ qrData, showQR, setShowQR }) => {
 		<>
 			<div className="mb-10 space-y-4 md:hidden">
 				<motion.a
-					href={
-						qrData
-							// added a dummy anchor to prevent reload (and loss of state) when returning to website on mobile device
-							? qrData + `&return_to=${encodeURIComponent(window.location.href + '#prevent_reload')}`
-							: ''
-					}
+					href={qrData ?? ''}
 					whileTap={{ scale: 0.95 }}
 					whileHover={{ scale: 1.05 }}
 					transition={{ layout: { duration: 0.15 } }}


### PR DESCRIPTION
Removes the default `return_to` value in IDKit. Resolves issues with UX on iOS where extra tabs or wrong browser may be opened.