### PR TITLE
feat: validate bridge_url

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -58,7 +58,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 	createClient: async ({ bridge_url, app_id, verification_level, action_description, action, signal }) => {
 		const { key, iv } = await generateKey()
 
-		const res = await fetch(`${bridge_url ?? DEFAULT_BRIDGE_URL}/request`, {
+		const res = await fetch(new URL('/request', bridge_url ?? DEFAULT_BRIDGE_URL), {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(
@@ -102,7 +102,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 		const key = get().key
 		if (!key) throw new Error('No keypair found. Please call `createClient` first.')
 
-		const res = await fetch(`${get().bridge_url}/response/${get().requestId}`)
+		const res = await fetch(new URL(`/response/${get().requestId}`, get().bridge_url))
 
 		if (!res.ok) {
 			return set({

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -60,7 +60,7 @@ export const useWorldBridgeStore = create<WorldBridgeStore>((set, get) => ({
 		const { key, iv } = await generateKey()
 
 		if (bridge_url) {
-			const validation = validate_bridge_url(bridge_url)
+			const validation = validate_bridge_url(bridge_url, app_id.includes('staging'))
 			if (!validation.valid) {
 				console.error(validation.errors.join('\n'))
 				set({ verificationState: VerificationState.Failed })

--- a/packages/core/src/lib/validation.ts
+++ b/packages/core/src/lib/validation.ts
@@ -1,0 +1,41 @@
+export type ValidationResponse = { valid: true } | { valid: false; errors: string[] }
+
+export function validate_bridge_url(bridge_url: string): ValidationResponse {
+	try {
+		new URL(bridge_url)
+	} catch (e) {
+		return { valid: false, errors: ['Failed to parse Bridge URL.'] }
+	}
+
+	const test_url = new URL(bridge_url)
+	const errors: string[] = []
+
+	if (test_url.protocol !== 'https:') {
+		errors.push('Bridge URL must use HTTPS.')
+	}
+	if (test_url.port) {
+		errors.push('Bridge URL must use the default port (443).')
+	}
+	if (test_url.pathname !== '/') {
+		errors.push('Bridge URL must not have a path.')
+	}
+	if (test_url.search) {
+		errors.push('Bridge URL must not have query parameters.')
+	}
+	if (test_url.hash) {
+		errors.push('Bridge URL must not have a fragment.')
+	}
+
+	// remove once restriction lifted in world app
+	if (!test_url.hostname.endsWith('worldcoin.org') && !test_url.hostname.endsWith('toolsforhumanity.com')) {
+		console.warn(
+			"Bridge URL should be a subdomain of worldcoin.org or toolsforhumanity.com. The user's identity wallet may refuse to connect. This is a temporary restriction and will be removed in the future."
+		)
+	}
+
+	if (errors.length) {
+		return { valid: false, errors }
+	}
+
+	return { valid: true }
+}

--- a/packages/core/src/lib/validation.ts
+++ b/packages/core/src/lib/validation.ts
@@ -1,6 +1,6 @@
 export type ValidationResponse = { valid: true } | { valid: false; errors: string[] }
 
-export function validate_bridge_url(bridge_url: string): ValidationResponse {
+export function validate_bridge_url(bridge_url: string, is_staging?: boolean): ValidationResponse {
 	try {
 		new URL(bridge_url)
 	} catch (e) {
@@ -9,6 +9,11 @@ export function validate_bridge_url(bridge_url: string): ValidationResponse {
 
 	const test_url = new URL(bridge_url)
 	const errors: string[] = []
+
+	if (is_staging && ['localhost', '127.0.0.1'].includes(test_url.hostname)) {
+		console.log('Using staging app_id with localhost bridge_url. Skipping validation.')
+		return { valid: true }
+	}
 
 	if (test_url.protocol !== 'https:') {
 		errors.push('Bridge URL must use HTTPS.')

--- a/packages/core/src/lib/validation.ts
+++ b/packages/core/src/lib/validation.ts
@@ -32,7 +32,7 @@ export function validate_bridge_url(bridge_url: string, is_staging?: boolean): V
 	}
 
 	// remove once restriction lifted in world app
-	if (!test_url.hostname.endsWith('worldcoin.org') && !test_url.hostname.endsWith('toolsforhumanity.com')) {
+	if (!test_url.hostname.endsWith('.worldcoin.org') && !test_url.hostname.endsWith('.toolsforhumanity.com')) {
 		console.warn(
 			"Bridge URL should be a subdomain of worldcoin.org or toolsforhumanity.com. The user's identity wallet may refuse to connect. This is a temporary measure and may be removed in the future."
 		)

--- a/packages/core/src/lib/validation.ts
+++ b/packages/core/src/lib/validation.ts
@@ -34,7 +34,7 @@ export function validate_bridge_url(bridge_url: string, is_staging?: boolean): V
 	// remove once restriction lifted in world app
 	if (!test_url.hostname.endsWith('worldcoin.org') && !test_url.hostname.endsWith('toolsforhumanity.com')) {
 		console.warn(
-			"Bridge URL should be a subdomain of worldcoin.org or toolsforhumanity.com. The user's identity wallet may refuse to connect. This is a temporary restriction and will be removed in the future."
+			"Bridge URL should be a subdomain of worldcoin.org or toolsforhumanity.com. The user's identity wallet may refuse to connect. This is a temporary measure and may be removed in the future."
 		)
 	}
 


### PR DESCRIPTION
Validates `bridge_url` in `idkit-core`, fails verification and throws error if:

- not https
- non-default port defined
- has a path
- has query parameters
- has a fragment

Logs a non-blocking console warning if the `bridge_url` hostname does not end with `worldcoin.org` or `toolsforhumanity.com` -- to be removed once the restriction is lifted in World App.

Additionally, `idkit-core` now properly handles trailing slash. A `bridge_url` input as `...coin.org/` or `...coin.org` will both function properly.