### PR TITLE
fix: bump zustand to ^4.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
 	"dependencies": {
 		"buffer": "^6.0.3",
 		"viem": "^1.19.11",
-		"zustand": "^4.3.3"
+		"zustand": "^4.5"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^6.13.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,7 @@
 		"posthog-js-lite": "2.4.0",
 		"qrcode": "^1.5.1",
 		"react-shadow": "^19.1.0",
-		"zustand": "^4.3.3"
+		"zustand": "^4.5"
 	},
 	"devDependencies": {
 		"@types/node": "18.11.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^1.19.11
         version: 1.19.11(typescript@5.3.3)
       zustand:
-        specifier: ^4.3.3
-        version: 4.4.1(@types/react@18.0.25)(react@18.2.0)
+        specifier: ^4.5
+        version: 4.5.2(@types/react@18.0.25)(react@18.2.0)
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.13.1
@@ -123,8 +123,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
       zustand:
-        specifier: ^4.3.3
-        version: 4.4.1(@types/react@18.0.25)(react@18.2.0)
+        specifier: ^4.5
+        version: 4.5.2(@types/react@18.0.25)(react@18.2.0)
     devDependencies:
       '@types/node':
         specifier: 18.11.9
@@ -243,7 +243,7 @@ importers:
         version: 21.6.0(typescript@5.3.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.8.6)(typescript@5.3.3)
+        version: 10.9.2(@types/node@20.11.26)(typescript@5.3.3)
       tsup:
         specifier: ^7.2.0
         version: 7.2.0(ts-node@10.9.2)(typescript@5.3.3)
@@ -1268,6 +1268,12 @@ packages:
 
   /@types/node@18.11.9:
     resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
+    dev: true
+
+  /@types/node@20.11.26:
+    resolution: {integrity: sha512-YwOMmyhNnAWijOBQweOJnQPl068Oqd4K3OFbTc6AHJwzweUwwWG3GIFY74OKks2PJUDkQPeddOQES9mLn1CTEQ==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/node@20.8.6:
@@ -4225,7 +4231,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      ts-node: 10.9.2(@types/node@20.8.6)(typescript@5.3.3)
+      ts-node: 10.9.2(@types/node@20.11.26)(typescript@5.3.3)
       yaml: 2.3.2
     dev: true
 
@@ -5071,7 +5077,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-node@10.9.2(@types/node@20.8.6)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@20.11.26)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -5090,7 +5096,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.8.6
+      '@types/node': 20.11.26
       acorn: 8.10.0
       acorn-walk: 8.3.1
       arg: 4.1.3
@@ -5336,6 +5342,10 @@ packages:
 
   /undici-types@5.25.3:
     resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /union@0.5.0:
@@ -5701,12 +5711,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zustand@4.4.1(@types/react@18.0.25)(react@18.2.0):
-    resolution: {integrity: sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==}
+  /zustand@4.5.2(@types/react@18.0.25)(react@18.2.0):
+    resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'
-      immer: '>=9.0'
+      immer: '>=9.0.6'
       react: '>=16.8'
     peerDependenciesMeta:
       '@types/react':


### PR DESCRIPTION
Zustand version was set to ^4.3.3, but we use `createWithEqualityFn` from `zustand/traditional`, which wasn't added until 4.4. Curiously, the lockfile had Zustand at 4.4.1.

Updating dependency version to ^4.5 (current latest minor release) resolves any potential dependency issues -- I have not run into it before (seems that usually Zustand 4.4 gets used?), but happened to get Zustand 4.3.x installed as a dependency in another project today and got the errors which this PR resolves.

Tested and working.