### PR TITLE
feat: enforce non-empty string for action in IDKit

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -19,12 +19,12 @@ export enum VerificationLevel {
 export type IDKitConfig = {
 	/** Unique identifier for the app verifying the action. This should be the app ID obtained from the Developer Portal. */
 	app_id: `app_${string}`
+	/** Identifier for the action the user is performing. Should be left blank for [Sign in with Worldcoin](https://docs.worldcoin.org/id/sign-in). */
+	action: AbiEncodedValue | string
 	/** The description of the specific action (shown to users in World App). Only recommended for actions created on-the-fly. */
 	action_description?: string
 	/** Encodes data into a proof that must match when validating. Read more on the [On-chain section](https://docs.worldcoin.org/advanced/on-chain). */
 	signal?: AbiEncodedValue | string
-	/** Identifier for the action the user is performing. Should be left blank for [Sign in with Worldcoin](https://docs.worldcoin.org/id/sign-in). */
-	action?: AbiEncodedValue | string
 	/** URL to a third-party bridge to use when connecting to the World App. Optional. */
 	bridge_url?: string
 	/** The minimum required level of verification. Defaults to "orb". */

--- a/packages/react/src/components/IDKitWidget/BaseWidget.tsx
+++ b/packages/react/src/components/IDKitWidget/BaseWidget.tsx
@@ -35,6 +35,9 @@ const IDKitWidget: FC<WidgetProps> = ({ children, ...config }) => {
 	const { isOpen, onOpenChange, stage, setOptions } = useIDKitStore(getParams, shallow)
 
 	useEffect(() => {
+		if (config.action === '') {
+			throw new Error(__('Action cannot be an empty string.'))
+		}
 		setOptions(config, ConfigSource.PROPS)
 	}, [config, setOptions])
 


### PR DESCRIPTION
requires the `action` prop to not be an empty string in IDKit react and standalone