### PR TITLE
ci: Update CI for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - uses: pnpm/action-setup@v2.4.0
+            - uses: pnpm/action-setup@v4
               with:
                   version: 8
 


### PR DESCRIPTION
Update CI release v2 no longer works and release is failing as a result 