### PR TITLE
ci: Add github packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
               uses: google-github-actions/release-please-action@v3
               with:
                   command: manifest
+                  release-type: node
 
     publish:
         needs: release
@@ -47,3 +48,33 @@ jobs:
               run: pnpm publish -r --report-summary
               env:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+    
+    publish-github:
+        needs: release
+        name: Publish
+        runs-on: ubuntu-latest
+        if: ${{ needs.release.outputs.releases_created }}
+        steps:
+            - uses: actions/checkout@v3
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 8
+
+            - name: Set up Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  cache: 'pnpm'
+                  registry-url: 'https://npm.pkg.github.com'
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Build
+              run: pnpm build
+
+            - name: Publish
+              run: pnpm publish -r --report-summary
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GIT_HUB_TOKEN}}


### PR DESCRIPTION
Include github release in CI. Some of our internal CI fetches packages from github packages instead which causes errors