### PR TITLE
update react-shadow to fix idkit modal in React 19 (Next.js 15)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,7 +67,7 @@
 		"copy-to-clipboard": "^3.3.3",
 		"framer-motion": "^11.2.14",
 		"qrcode": "^1.5.3",
-		"react-shadow": "^19.1.0",
+		"react-shadow": "^20.6.0",
 		"zustand": "^4.5.4"
 	},
 	"devDependencies": {


### PR DESCRIPTION
# Update react-shadow dependency to fix React 19 compatibility

## Issue
When using `@worldcoin/idkit` with React 19 (Next.JS 15), the IDKit modal fails to render properly due to an issue in the underlying `react-shadow` dependency. Specifically, the shadow DOM initialization fails because of undefined `styleSheets` handling in older versions of `react-shadow`.

## Solution
Update the `react-shadow` dependency to version ^20.6.0, which includes improved React 19 compatibility and better handling of shadow DOM initialization.  react-shadow 20.6.0 is compatible with versions of react back to 16.8 up to 19, so there shouldn't be any issues with updating this dependency.

## Changes
- Updated `react-shadow` from previous version to ^20.6.0 in package.json

## Testing
- Verified IDKit modal renders correctly with React 19 (Next.js 15)

## Additional Context
This update is particularly important for projects using React 19, as the current version can cause runtime errors when attempting to initialize the IDKit modal's shadow DOM.