### PR TITLE
fix: client side error from no dialog title for accessibility

### DIFF
--- a/packages/react/src/components/IDKitWidget/BaseWidget.tsx
+++ b/packages/react/src/components/IDKitWidget/BaseWidget.tsx
@@ -116,6 +116,7 @@ const IDKitWidget: FC<WidgetProps> = ({
 												onPointerDownOutside={avoidDefaultDomBehavior}
 												onInteractOutside={avoidDefaultDomBehavior}
 											>
+												<Dialog.Title />
 												<motion.div
 													layout={media == 'mobile' ? 'position' : true}
 													exit={media == 'mobile' ? 'initMob' : 'init'}


### PR DESCRIPTION
Getting a client side error related to DialogContent not having DialogTitle when opening the base widget with the QR code. Error message is:
```
DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.

If you want to hide the `DialogTitle`, you can wrap it with our VisuallyHidden component.

For more information, see https://radix-ui.com/primitives/docs/components/dialog
```