### PR TITLE
fix: add headers param to verifyCloudProof

### DIFF
--- a/packages/core/src/lib/backend.ts
+++ b/packages/core/src/lib/backend.ts
@@ -14,7 +14,8 @@ export async function verifyCloudProof(
 	app_id: `app_${string}`,
 	action: string,
 	signal?: string,
-	endpoint?: URL | string
+	endpoint?: URL | string,
+	headers?: Record<string, string>
 ): Promise<IVerifyResponse> {
 	if (isBrowser) {
 		throw new Error('verifyCloudProof can only be used in the backend.')
@@ -23,6 +24,7 @@ export async function verifyCloudProof(
 	const response = await fetch(endpoint ?? `https://developer.worldcoin.org/api/v2/verify/${app_id}`, {
 		method: 'POST',
 		headers: {
+			...(headers ?? {}),
 			'Content-Type': 'application/json',
 		},
 		body: JSON.stringify({


### PR DESCRIPTION
In Cloudflare worker environment, fetch doesn't have default 'User-Agent' setting for the `fetch`. 
Which results in below error. 

```
SyntaxError: Unexpected token '<', "<html>
<h"... is not valid JSON
    at verifyCloudProof ([redacted]/@worldcoin_minikit-js.js:63707:33)
    at Array.verify ([redacted]/packages/web/worker/endpoints/verify.ts:17:22)
```

The returned response is as following
```
Response {
  status: 403,
  statusText: 'Forbidden',
  headers: Headers(5) {
    'connection' => 'keep-alive',
    'content-length' => '118',
    'content-type' => 'text/html',
    'date' => 'Sat, 10 May 2025 13:11:08 GMT',
    'server' => 'awselb/2.0',
    [immutable]: true
  },
  ok: false,
  redirected: false,
  url: 'https://developer.worldcoin.org/api/v2/verify/[redacted]',
  webSocket: null,
  cf: undefined,
  type: 'default',
  body: ReadableStream {
    locked: false,
    [state]: 'readable',
    [supportsBYOB]: true,
    [length]: 118n
  },
  bodyUsed: false
}
```
And the global fetch is not configurable in  Cloudflare worker environment.

So I propose adding a `headers` param to  `verifyCloudProof` function to customize the header of the request.

Thx!