### PR TITLE
Unhashed signal

### DIFF
--- a/.changeset/silver-dodos-listen.md
+++ b/.changeset/silver-dodos-listen.md
@@ -1,0 +1,5 @@
+---
+'@worldcoin/idkit-core': patch
+---
+
+support unhashed signal for idkit

--- a/packages/core/src/lib/hashing.ts
+++ b/packages/core/src/lib/hashing.ts
@@ -67,8 +67,8 @@ export const solidityEncode = (types: string[], values: unknown[]): AbiEncodedVa
 	return { types, values } as AbiEncodedValue
 }
 
-export const generateSignal = (signal: IDKitConfig['signal']): HashFunctionOutput => {
-	if (!signal || typeof signal === 'string') return hashToField(signal ?? '')
+export const generateSignal = (signal: IDKitConfig['signal']): HashFunctionOutput | string => {
+	if (!signal || typeof signal === 'string') return signal ?? ''
 
 	return packAndEncode(signal.types.map((type, index) => [type, signal.values[index]]))
 }


### PR DESCRIPTION
Default signal should be unhashed so in app user can see what the signal they are signing for actually is