### PR TITLE
fix: migrate framer-motion to motion for React 19 support

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
 		"@tailwindcss/forms": "^0.5.7",
 		"@worldcoin/idkit-core": "workspace:*",
 		"copy-to-clipboard": "^3.3.3",
-		"framer-motion": "^11.2.14",
+		"motion": "^12.0.0",
 		"qrcode": "^1.5.3",
 		"zustand": "^4.5.4"
 	},
@@ -81,8 +81,8 @@
 	"main": "src/index.ts",
 	"name": "@worldcoin/idkit",
 	"peerDependencies": {
-		"react": ">18.0.0",
-		"react-dom": ">18.0.0"
+		"react": ">=18.0.0",
+		"react-dom": ">=18.0.0"
 	},
 	"private": false,
 	"publishConfig": {

--- a/packages/react/src/components/IDKitWidget/BaseWidget.tsx
+++ b/packages/react/src/components/IDKitWidget/BaseWidget.tsx
@@ -17,7 +17,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import type { WidgetProps } from '@/types/config'
 import { __, setLocalizationConfig } from '@/lang'
 import { Fragment, useEffect, useMemo } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'motion/react'
 import HostAppVerificationState from './States/HostAppVerificationState'
 
 const getParams = ({ open, processing, onOpenChange, stage, setStage, setOptions, setErrorState }: IDKitStore) => ({

--- a/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
+++ b/packages/react/src/components/IDKitWidget/States/WorldID/QRState.tsx
@@ -4,7 +4,7 @@ import type { FC } from 'react'
 import copy from 'copy-to-clipboard'
 import Qrcode from '@/components/QRCode'
 import { useCallback, useState } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'motion/react'
 import WorldcoinIcon from '@/components/Icons/WorldcoinIcon'
 import QRPlaceholderIcon from '@/components/Icons/QRPlaceholderIcon'
 


### PR DESCRIPTION
## Summary
- Fixes #388 — framer-motion v11 is not React 19 compatible
- Replaced framer-motion with motion v12 (same API, just renamed package)
- Changed import path from framer-motion to motion/react
- Updated peer deps to include React 19